### PR TITLE
Many registered array_h

### DIFF
--- a/src/cuda_xengine.cu
+++ b/src/cuda_xengine.cu
@@ -361,6 +361,18 @@ int xgpuClearDeviceIntegrationBuffer(XGPUContext *context)
 #define ELAPSED_NS(start,stop) \
   (((int64_t)stop.tv_sec-start.tv_sec)*1000*1000*1000+(stop.tv_nsec-start.tv_nsec))
 
+ComplexInput* xgpuSetUnregisterArrayPtr(XGPUContext *context, ComplexInput* unregister_array_h)
+{
+  XGPUInternalContext *internal = (XGPUInternalContext *)context->internal;
+  if(!internal) {
+    errno = EINVAL;
+    return NULL;
+  }
+  ComplexInput* previously = internal->unregister_array_h;
+  internal->unregister_array_h = unregister_array_h;
+  return previously;
+}
+
 // Specify a new host input buffer.
 int xgpuSetHostInputBuffer(XGPUContext *context)
 {

--- a/src/xgpu.h
+++ b/src/xgpu.h
@@ -173,6 +173,12 @@ int xgpuInit(XGPUContext *context, int device_flags);
 // integration.
 int xgpuClearDeviceIntegrationBuffer(XGPUContext *context);
 
+// Specify internal->unregister_array_h.
+//
+// The previous internal->unregister_array_h is returned. This hack
+// enables one to avoid the deregistration of the previous array_h.
+ComplexInput* xgpuSetUnregisterArrayPtr(XGPUContext *context, ComplexInput* unregister_array_h);
+
 // Specify a new host input buffer.
 //
 // The previous host input buffer is freed or unregistered (as required) and


### PR DESCRIPTION
# Context
Employ xGPU in a hashpipe thread: hashpipe has each thread fill and pass downstream a buffer at a time, cycling through N buffers cyclically.
The `SetHostInputBuffer()` call on each new buffer is imperative to maximum performance due to the underlying `cudaHostRegister()` call (without it, performance is observed to be halved). The `SetHostInputBuffer()` call is timed to take 9 ms however, which is impractical for the target real-time scenario. The `SetHostInputBuffer()` call also deregisters the previous buffer, making preemptive registration of all blocks impossible.

# Goal
Provide a way for user-source to pre-emptively register all their buffers.

## Solution 1 (implemented in 1f8ad6794dd4bb16b87f36d5155021dc8d22955a)
Provide a function to manually set the `context->internal->unregister_array_h` pointer. If set to `NULL` subsequent `SetHostInputBuffer()` calls do not deregister the previous array. The suggested function should return the displaced pointer for user-management. The user will have to manage deregistration of their buffers later, e.g.:

## Solution 2
Expose the `XGPUInternalContext` definition so that the user can manually adjust the `context->internal->unregister_array_h` pointer, to the same effect as Solution 1.
### Cons
This opens up too much control to the user.

## Solution 3
The user manually registers their buffers.
### Cons
The logic inside `SetHostInputBuffer()` (particularly page-alignment) is either mimicked by the user or lost.